### PR TITLE
support setting string slices from []string

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -111,6 +111,13 @@ func (d *decodeState) decode(input interface{}, output reflect.Value, base strin
 		}
 		return any
 
+	case []string:
+		any := false
+		for key, value := range input {
+			any = d.decodeKeyValue(strconv.Itoa(key), value, output, base) || any
+		}
+		return any
+
 	default:
 		set, err := setValue(output, input)
 		if !set || err != nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -27,6 +27,7 @@ func TestDecode(t *testing.T) {
 		input := d{
 			"x": d{
 				"y": l{2},
+				"z": []string{"2", "3"},
 			},
 			"x.y.0": 3, // should always take precedence
 
@@ -43,6 +44,7 @@ func TestDecode(t *testing.T) {
 		type into struct {
 			X struct {
 				Y []int
+				Z []string
 			}
 			Z []map[string]interface{}
 			F int
@@ -51,11 +53,14 @@ func TestDecode(t *testing.T) {
 
 		res := Decode(input, &output)
 		assert.Error(t, res.Error)
-		assert.DeepEqual(t, res.Used, s("x.y.0", "x.y.0", "z.0.q", "z.1.q", "z.2.q"))
+		assert.DeepEqual(t, res.Used, s("x.y.0", "x.y.0", "z.0.q", "z.1.q", "z.2.q", "x.z.0", "x.z.1"))
 		assert.DeepEqual(t, res.Missing, s("q.f"))
 		assert.DeepEqual(t, res.Broken, s("f"))
 		assert.DeepEqual(t, output, into{
-			X: struct{ Y []int }{Y: []int{3}},
+			X: struct {
+				Y []int
+				Z []string
+			}{Y: []int{3}, Z: []string{"2", "3"}},
 			Z: []map[string]interface{}{{"q": 0}, {"q": 1}, {"q": 2}},
 		})
 	})

--- a/value.go
+++ b/value.go
@@ -49,19 +49,24 @@ func setValue(output reflect.Value, input interface{}) (set bool, err error) {
 	case typ == timeType:
 		val, err = cast.ToTimeE(input)
 	case typ == stringSliceType:
-		var sval string
-		sval, err = cast.ToStringE(input)
-		if err != nil {
-			return false, err
-		}
-		sval = trimByteFront(sval, '[')
-		sval = trimByteFront(sval, '"')
-		sval = trimByteBack(sval, ']')
-		sval = trimByteBack(sval, '"')
-		if len(sval) > 0 {
-			val, err = csv.NewReader(strings.NewReader(sval)).Read()
-		} else {
-			val = []string(nil)
+		switch i := input.(type) {
+		case []string:
+			val = i
+		default:
+			var sval string
+			sval, err = cast.ToStringE(input)
+			if err != nil {
+				return false, err
+			}
+			sval = trimByteFront(sval, '[')
+			sval = trimByteFront(sval, '"')
+			sval = trimByteBack(sval, ']')
+			sval = trimByteBack(sval, '"')
+			if len(sval) > 0 {
+				val, err = csv.NewReader(strings.NewReader(sval)).Read()
+			} else {
+				val = []string(nil)
+			}
 		}
 
 	// if it can be set by string, do that


### PR DESCRIPTION
After storj/private@9531a5d gateway services complain about the `[]string` configuration parameters:

```
2022-07-28T18:26:19.606+0200    INFO    process/exec_conf.go:307        Invalid configuration file value for key        {"Key": "client-trusted-ips-list"}
```

Let's assume we have the following config struct:

```
// Define a config struct and some flags.
	var config struct {
		X int      `default:"0"`
		S []string `default:""`
		P []string `default:""`
	}
```

And load values of S from configuration file:

```
Bind(cmd, &config)

	// Run the command through the exec call.
	ExecWithCustomConfig(cmd, false, func(cmd *cobra.Command, vip *viper.Viper) error {
		// only, because extension is used to choose the right un-marshaller
		vip.SetConfigFile("config.yaml")
		err := vip.ReadConfig(strings.NewReader("x: 1\ns: [a,b]\n"))

		require.Equal(t, "[]string", reflect.TypeOf(vip.AllSettings()["p"]).String())
		require.Equal(t, "[]interface {}", reflect.TypeOf(vip.AllSettings()["s"]).String())
		return err
	})
```

As you can see `p` (not set) is `[]string`, while `s` (configured) is `[]interface{}`.

`zeebo/struct` couldn't understand `[]string` only `[]interface{}`. Technically it's not a problem, as it fails only when the array is empty, but it prints out an unnecessary warning.

The exact type (`[]string`) depends on the `bindConfig` method in `cfgstruct/bind.go` (storj/private). There is no easy way there to use `[]interface{}` instead of `[]string` as pflag doesn't support it.

Seems to be easier here to fix the struct parsing and support booth `"string" -> []string{}` and `[]string -> []string{}` injection.
